### PR TITLE
linsolve: add CG

### DIFF
--- a/linsolve/cg.go
+++ b/linsolve/cg.go
@@ -1,0 +1,100 @@
+// Copyright ©2016 The Gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package linsolve
+
+import "gonum.org/v1/gonum/floats"
+
+// CG implements the Conjugate Gradient iterative method with
+// preconditioning for solving systems of linear equations
+//  A*x = b,
+// where A is a symmetric positive definite matrix.
+//
+// References:
+//  - Barrett, Richard et al. (1994). Section 2.3.1 Conjugate Gradient Method (CG).
+//    In Templates for the Solution of Linear Systems: Building Blocks for
+//    Iterative Methods (2nd ed.) (pp. 12-15). Philadelphia, PA: SIAM.
+//    Retrieved from http://www.netlib.org/templates/templates.pdf
+//  - Hestenes, M., and Stiefel, E. (1952). Methods of conjugate gradients for
+//    solving linear systems. Journal of Research of the National Bureau of
+//    Standards, 49(6), 409. doi:10.6028/jres.049.044
+//  - Málek, J. and Strakoš, Z. (2015). Preconditioning and the Conjugate Gradient
+//    Method in the Context of Solving PDEs. Philadelphia, PA: SIAM.
+type CG struct {
+	rho, rhoPrev float64
+
+	z  []float64
+	p  []float64
+	ap []float64
+
+	first  bool
+	resume int
+}
+
+// Init implements the Method interface.
+func (cg *CG) Init(dim int) {
+	if dim <= 0 {
+		panic("cg: dimension not positive")
+	}
+
+	cg.z = reuse(cg.z, dim)
+	cg.p = reuse(cg.p, dim)
+	cg.ap = reuse(cg.ap, dim)
+	cg.first = true
+	cg.resume = 1
+}
+
+// Iterate implements the Method interface. It will command the following
+// operations:
+//  MulVec
+//  PreconSolve
+//  CheckResidual
+//  EndIteration
+func (cg *CG) Iterate(ctx *Context) (Operation, error) {
+	switch cg.resume {
+	case 1:
+		ctx.Src = ctx.Residual
+		ctx.Dst = cg.z
+		cg.resume = 2
+		// Compute z_{i-1} = M^{-1} * r_{i-1}.
+		return PreconSolve, nil
+	case 2:
+		cg.rho = floats.Dot(ctx.Residual, cg.z) // ρ_{i-1} = r_{i-1} · z_{i-1}
+		if cg.first {
+			copy(cg.p, cg.z) // p_1 = z_0
+		} else {
+			beta := cg.rho / cg.rhoPrev                // β_{i-1} = ρ_{i-1} / ρ_{i-2}
+			floats.AddScaledTo(cg.p, cg.z, beta, cg.p) // p_i = z_{i-1} + β p_{i-1}
+		}
+
+		ctx.Src = cg.p
+		ctx.Dst = cg.ap
+		cg.resume = 3
+		// Compute A * p_i.
+		return MulVec, nil
+	case 3:
+		alpha := cg.rho / floats.Dot(cg.p, cg.ap)     // α_i = ρ_{i-1} / (p_i · A p_i)
+		floats.AddScaled(ctx.Residual, -alpha, cg.ap) // r_i = r_{i-1} - α A p_i
+		floats.AddScaled(ctx.X, alpha, cg.p)          // x_i = x_{i-1} + α p_i
+
+		ctx.Src = nil
+		ctx.Dst = nil
+		ctx.Converged = false
+		cg.resume = 4
+		return CheckResidual, nil
+	case 4:
+		if ctx.Converged {
+			// Calling Iterate again without Init will panic.
+			cg.resume = 0
+			return EndIteration, nil
+		}
+		cg.rhoPrev = cg.rho
+		cg.first = false
+		cg.resume = 1
+		return EndIteration, nil
+
+	default:
+		panic("cg: Init not called")
+	}
+}

--- a/linsolve/cg.go
+++ b/linsolve/cg.go
@@ -4,7 +4,9 @@
 
 package linsolve
 
-import "gonum.org/v1/gonum/floats"
+import (
+	"gonum.org/v1/gonum/floats"
+)
 
 // CG implements the Conjugate Gradient iterative method with
 // preconditioning for solving systems of linear equations

--- a/linsolve/cg_example_test.go
+++ b/linsolve/cg_example_test.go
@@ -1,0 +1,133 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package linsolve_test
+
+import (
+	"fmt"
+	"math"
+
+	"gonum.org/v1/exp/linsolve"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/mat"
+)
+
+type system struct {
+	A *mat.SymBandDense
+	b []float64
+}
+
+// L2Projection returns a linear system whose solution is the L2 projection of f
+// into the space of piecewise linear functions defined on the given grid.
+//
+// References:
+//  - M. Larson, F. Bengzon, The Finite Element Method: Theory,
+//    Implementations, and Applications. Springer (2013), Section 1.3, also
+//    available at:
+//    http://www.springer.com/cda/content/document/cda_downloaddocument/9783642332869-c1.pdf
+func L2Projection(grid []float64, f func(float64) float64) system {
+	n := len(grid)
+
+	// Allocate the mass matrix.
+	lda := 2
+	a := make([]float64, n*lda)
+	// Assemble the mass matrix by iterating over all elements.
+	for i := 0; i < n-1; i++ {
+		// h is the length of the i-th element.
+		h := grid[i+1] - grid[i]
+		// Add contribution from the i-th element, first the two diagonal
+		// elements, then the one off-diagonal element.
+		a[i*lda] += h / 3
+		a[(i+1)*lda] += h / 3
+		a[i*lda+1] += h / 6
+	}
+	A := mat.NewSymBandDense(n, 1, a)
+
+	// Allocate the load vector.
+	b := make([]float64, n)
+	// Assemble the load vector by iterating over all elements.
+	for i := 0; i < n-1; i++ {
+		h := grid[i+1] - grid[i]
+		b[i] += f(grid[i]) * h / 2
+		b[i+1] += f(grid[i+1]) * h / 2
+	}
+
+	return system{A, b}
+}
+
+// UniformGrid returns a slice of n+1 evenly spaced values between
+// x0 and x1, inclusive.
+func UniformGrid(x0, x1 float64, n int) []float64 {
+	h := (x1 - x0) / float64(n)
+	grid := make([]float64, n+1)
+	for i := range grid {
+		grid[i] = x0 + float64(i)*h
+	}
+	grid[n] = x1
+	return grid
+}
+
+func ExampleCG() {
+	const tol = 1e-6
+
+	grid := UniformGrid(0, 1, 10)
+	sys := L2Projection(grid, func(x float64) float64 {
+		return x * math.Sin(x)
+	})
+	n := sys.A.Symmetric()
+
+	ctx := linsolve.Context{
+		X:        make([]float64, n),
+		Residual: make([]float64, n),
+	}
+	copy(ctx.Residual, sys.b)
+
+	if floats.Norm(ctx.Residual, 2) < tol {
+		fmt.Println("Initial estimate is sufficiently accurate")
+		return
+	}
+
+	bnorm := floats.Norm(sys.b, 2)
+	var (
+		numiter int
+		rnorms  []float64
+		cg      linsolve.CG
+	)
+	cg.Init(n)
+MainLoop:
+	for {
+		op, err := cg.Iterate(&ctx)
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
+		switch op {
+		case linsolve.MulVec:
+			dst := mat.NewVecDense(n, ctx.Dst)
+			dst.MulVec(sys.A, mat.NewVecDense(n, ctx.Src))
+		case linsolve.PreconSolve:
+			copy(ctx.Dst, ctx.Src)
+		case linsolve.CheckResidual:
+			rnorm := floats.Norm(ctx.Residual, 2) / bnorm
+			rnorms = append(rnorms, rnorm)
+			if rnorm < tol {
+				ctx.Converged = true
+			}
+		case linsolve.EndIteration:
+			numiter++
+			if ctx.Converged {
+				break MainLoop
+			}
+		}
+	}
+
+	fmt.Printf("# iterations: %v\n", numiter)
+	fmt.Printf("Residual history: %.6g\n", rnorms)
+	fmt.Printf("Final solution: %.6f\n", ctx.X)
+
+	// Output:
+	// # iterations: 10
+	// Residual history: [0.136572 0.0674303 0.0249177 0.00703348 0.00186369 0.000477831 0.000122098 2.98577e-05 6.44331e-06 5.46512e-07]
+	// Final solution: [-0.003341 0.006678 0.036530 0.085606 0.152981 0.237072 0.337006 0.447616 0.578244 0.682719 0.920847]
+}

--- a/linsolve/doc.go
+++ b/linsolve/doc.go
@@ -17,10 +17,14 @@ References:
 */
 package linsolve
 
-// TODO(vladimir-ch): Improve documentation. Write an introduction about
-// iterative methods and that they can be more efficient than direct methods
-// when we are solving large (sparse) systems, when the solution does not have
-// to be known to machine precision. Write that the matrix is accessed only via
-// matrix-vector products. Write that the documentation is written from the
-// perspective of users who want to call Iterative and designers who want to
-// implement Method (or direct users of Method?).
+// TODO(vladimir-ch): Improve documentation:
+//  - Write an introduction about iterative methods and that they can be more
+//    efficient than direct methods when we are solving large (sparse) systems,
+//    when the solution does not have to be known to machine precision.
+//  - Write that the matrix is accessed only via matrix-vector products.
+//  - Write that the documentation is written from the perspective of users who
+//    want to call Iterative and designers who want to implement Method (or
+//    direct users of Method?).
+//  - Specify how the data in Context works (who needs to create what).
+//  - Mention that the package does not (cannot) check that a matrix has
+//    properties (like SPD) required by the method.

--- a/linsolve/doc.go
+++ b/linsolve/doc.go
@@ -2,7 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package linsolve provides iterative algorithms for solving linear systems.
+/*
+Package linsolve provides iterative algorithms for solving linear systems.
+
+References:
+ - Barrett, Richard et al. (1994). Templates for the Solution of Linear Systems: Building
+   Blocks for Iterative Methods (2nd ed.). Philadelphia, PA: SIAM.
+   Retrieved from http://www.netlib.org/templates/templates.pdf
+ - Saad, Yousef (2003). Iterative methods for sparse linear systems (2nd ed.).
+   Philadelphia, PA: SIAM.
+   Retrieved from http://www-users.cs.umn.edu/~saad/IterMethBook_2ndEd.pdf
+ - Greenbaum, A. (1997). Iterative methods for solving linear systems.
+   Philadelphia, PA: SIAM.
+*/
 package linsolve
 
 // TODO(vladimir-ch): Improve documentation. Write an introduction about

--- a/linsolve/linsolve.go
+++ b/linsolve/linsolve.go
@@ -21,6 +21,9 @@ type Method interface {
 	// linear system.
 	Init(dim int)
 
+	// Iterate performs a step in converging to the
+	// solution of a linear system.
+	//
 	// Iterate retrieves data from Context, updates it,
 	// and returns the next operation. The caller must
 	// perform the Operation using data in Context, and


### PR DESCRIPTION
This PR adds the Conjugate Gradient method as a concrete implementation of `Method` together with an example on how it can be used directly without any convenience wrapper. Here this direct access to the loop is used to collect the residual norms which could later be used for example for plotting the convergence behaviour.

Real tests will come in a future PR because they need some machinery in place first.