### PR TITLE
linsolve: merge CheckResidual and EndIteration operations

### DIFF
--- a/linsolve/cg.go
+++ b/linsolve/cg.go
@@ -47,8 +47,7 @@ func (cg *CG) Init(dim int) {
 // operations:
 //  MulVec
 //  PreconSolve
-//  CheckResidual
-//  EndIteration
+//  MajorIteration
 func (cg *CG) Iterate(ctx *Context) (Operation, error) {
 	switch cg.resume {
 	case 1:
@@ -75,19 +74,10 @@ func (cg *CG) Iterate(ctx *Context) (Operation, error) {
 		floats.AddScaled(ctx.Residual, -alpha, ap) // r_i = r_{i-1} - α A p_i
 		floats.AddScaled(ctx.X, alpha, cg.p)       // x_i = x_{i-1} + α p_i
 
-		ctx.Converged = false
-		cg.resume = 4
-		return CheckResidual, nil
-	case 4:
-		if ctx.Converged {
-			// Calling Iterate again without Init will panic.
-			cg.resume = 0
-			return EndIteration, nil
-		}
 		cg.rhoPrev = cg.rho
 		cg.first = false
 		cg.resume = 1
-		return EndIteration, nil
+		return MajorIteration, nil
 
 	default:
 		panic("cg: Init not called")

--- a/linsolve/cg_example_test.go
+++ b/linsolve/cg_example_test.go
@@ -110,15 +110,11 @@ MainLoop:
 			dst.MulVec(sys.A, mat.NewVecDense(n, ctx.Src))
 		case linsolve.PreconSolve:
 			copy(ctx.Dst, ctx.Src)
-		case linsolve.CheckResidual:
+		case linsolve.MajorIteration:
+			numiter++
 			rnorm := floats.Norm(ctx.Residual, 2) / bnorm
 			rnorms = append(rnorms, rnorm)
 			if rnorm < tol {
-				ctx.Converged = true
-			}
-		case linsolve.EndIteration:
-			numiter++
-			if ctx.Converged {
 				break MainLoop
 			}
 		}

--- a/linsolve/cg_test.go
+++ b/linsolve/cg_test.go
@@ -73,14 +73,10 @@ testLoop:
 				tc.mulvec(ctx.Dst, ctx.Src, false)
 			case PreconSolve:
 				copy(ctx.Dst, ctx.Src)
-			case CheckResidual:
+			case MajorIteration:
+				itercount++
 				rnorm := floats.Norm(ctx.Residual, math.Inf(1))
 				if rnorm < 1e-13 {
-					ctx.Converged = true
-				}
-			case EndIteration:
-				itercount++
-				if ctx.Converged {
 					break cgLoop
 				}
 				if itercount == tc.iters {

--- a/linsolve/linsolve.go
+++ b/linsolve/linsolve.go
@@ -44,28 +44,19 @@ type Context struct {
 
 	// Residual is the current residual b-A*x. On the
 	// first call to Method.Iterate Residual must
-	// contain the initial residual. Method will make
-	// sure it is set to a valid value when it commands
-	// CheckResidual.
-	// TODO(vladimir-ch): Consider whether the behavior
-	// should also include: Method will update Residual
-	// with the current value of b-A*x when it commands
-	// EndIteration. Probably not because of GMRES.
+	// contain the initial residual. Method will update
+	// it to the current value when it commands
+	// MajorIteration.
 	Residual []float64
 
-	// ResidualNorm is (an estimate of) the norm of the
-	// current residual. Method will set it to a valid
+	// ResidualNorm is (an estimate of) a norm of
+	// the residual. Method will set it to the current
 	// value when it commands CheckResidualNorm.
 	ResidualNorm float64
 
-	// Converged indicates to Method whether the
-	// Residual or the ResidualNorm satisfies the
-	// stopping criterion as a result of CheckResidual
-	// or CheckResidualNorm operation. If Converged is
-	// set to true, Method will then command
-	// EndIteration with Converged set to true. After
-	// that the caller must not call Method.Iterate
-	// again without calling Method.Init first.
+	// Converged indicates to Method whether ResidualNorm
+	// satisfies a stopping criterion as a result of
+	// CheckResidualNorm operation.
 	Converged bool
 
 	// Src and Dst are the source and destination
@@ -102,30 +93,23 @@ const (
 	// result must be placed into Context.Residual.
 	ComputeResidual
 
-	// Check convergence using the current approximation
-	// in Context.X and the current residual
-	// Context.Residual. The caller must set
-	// Context.Converged to indicate whether convergence
-	// has been determined, and then it must call
-	// Method.Iterate again.
-	CheckResidual
-
-	// Check convergence using the current approximation
-	// in Context.X and the residual norm in
-	// Context.ResidualNorm. The caller must set
+	// Check convergence using (an estimate of) a
+	// residual norm in Context.ResidualNorm. Context.X
+	// does not need to be valid. The caller must set
 	// Context.Converged to indicate whether convergence
 	// has been determined, and then it must call
 	// Method.Iterate again.
 	CheckResidualNorm
 
-	// EndIteration indicates that Method has finished
-	// what it considers to be one iteration. If
-	// Context.Converged is true, Context.X contains the
-	// approximate solution and the caller must
-	// terminate the iterative process. If the caller
-	// performs a new iterative run, it must call
-	// Method.Init before calling Method.Iterate.
-	EndIteration
+	// MajorIteration indicates that Method has finished
+	// what it considers to be one iteration. Method
+	// will make sure that Context.X and
+	// Context.Residual are updated. The caller should
+	// check convergence and other stopping criteria,
+	// and it may call Method.Iterate again if
+	// necessary. Otherwise it can terminate the
+	// iterative process.
+	MajorIteration
 )
 
 func reuse(v []float64, n int) []float64 {


### PR DESCRIPTION
The main reason for having CheckResidual and CheckResidualNorm separated from EndIteration was to allow Methods to do any necessary updates to Context after convergence has been detected.

This happens in GMRES which can detect convergence in a preliminary way by using an estimate of the residual norm without having to form x (which is a relatively expensive operation). x is then formed only when convergence is detected after `CheckResidualNorm` (or when restarting) but before `EndIteration` is commanded. However, this leads to problems and loose ends: the final residual norm estimate wouldn't be equal to the true residual norm and the residual would not be formed upon termination making the state of the final Context strange (X valid, ResidualNorm approximate, Residual not up-to-date).

Based on this reasoning this PR merges `CheckResidual` and `EndIteration` operations into a single `MajorIteration` operation upon which Context.X and Context.Residual must be up-to-date (see the removed TODO). The convergence is then checked based on the true residual. As a side effect it changes the meaning of what one iteration is for GMRES but this can be considered later. Making this change also simplifies the code and we also follow more closely the names and behavior of the optimize package.

The tests for GMRES had to be adapted because now the convergence checks are made using different values.