### PR TITLE
linsolve: rework Settings

### DIFF
--- a/linsolve/iterative.go
+++ b/linsolve/iterative.go
@@ -12,9 +12,15 @@ import (
 
 const defaultTolerance = 1e-8
 
-// ErrIterationLimit is returned when a maximum number of iterations were done
-// without converging to a solution.
-var ErrIterationLimit = errors.New("linsolve: iteration limit reached")
+var (
+	// ErrIterationLimit is returned when a maximum number of iterations were done
+	// without converging to a solution.
+	ErrIterationLimit = errors.New("linsolve: iteration limit reached")
+
+	// ErrNoProgress is returned when a Method stagnates, that is, when the
+	// difference between two consecutive iterates is too small.
+	ErrNoProgress = errors.New("linsolve: no progress")
+)
 
 // MulVecToer represents a square matrix A by means of a matrix-vector
 // multiplication.
@@ -194,6 +200,7 @@ func iterate(a MulVecToer, b []float64, ctx *Context, settings Settings, method 
 	if bNorm == 0 {
 		bNorm = 1
 	}
+	copy(settings.Dst, ctx.X)
 
 	n := len(b)
 	method.Init(n)
@@ -221,7 +228,6 @@ func iterate(a MulVecToer, b []float64, ctx *Context, settings Settings, method 
 			computeResidual(ctx.Residual, a, b, ctx.X, stats)
 		case MajorIteration:
 			stats.Iterations++
-			copy(settings.Dst, ctx.X)
 			rNorm := floats.Norm(ctx.Residual, 2)
 			var converged bool
 			if settings.NormA != 0 {
@@ -231,9 +237,14 @@ func iterate(a MulVecToer, b []float64, ctx *Context, settings Settings, method 
 				converged = rNorm < settings.Tolerance*bNorm
 			}
 			if converged {
+				copy(settings.Dst, ctx.X)
 				ctx.ResidualNorm = rNorm
 				return nil
 			}
+			if floats.Distance(settings.Dst, ctx.X, 2) <= eps*floats.Norm(ctx.X, 2) {
+				return ErrNoProgress
+			}
+			copy(settings.Dst, ctx.X)
 			if stats.Iterations == settings.MaxIterations {
 				return ErrIterationLimit
 			}

--- a/linsolve/iterative.go
+++ b/linsolve/iterative.go
@@ -94,7 +94,7 @@ func checkSettings(s *Settings, dim int) {
 	if s.InitX != nil && len(s.InitX) != dim {
 		panic("linsolve: mismatched length of initial guess")
 	}
-	if s.Dst != nil && len(s.Dst) != dim {
+	if len(s.Dst) != dim {
 		panic("linsolve: mismatched destination length")
 	}
 	if s.Tolerance <= 0 || 1 <= s.Tolerance {
@@ -103,7 +103,7 @@ func checkSettings(s *Settings, dim int) {
 	if s.MaxIterations <= 0 {
 		panic("linsolve: negative iteration limit")
 	}
-	if s.Work != nil && !checkContext(s.Work, dim) {
+	if !checkContext(s.Work, dim) {
 		panic("linsolve: mismatched size of work context")
 	}
 }

--- a/linsolve/iterative.go
+++ b/linsolve/iterative.go
@@ -187,6 +187,9 @@ func Iterative(a MulVecToer, b []float64, m Method, settings *Settings) (*Result
 		computeResidual(ctx.Residual, a, b, ctx.X, &stats)
 	} else {
 		// Initial x is the zero vector.
+		for i := range ctx.X {
+			ctx.X[i] = 0
+		}
 		// Residual b-A*x is then equal to b.
 		copy(ctx.Residual, b)
 	}

--- a/linsolve/iterative.go
+++ b/linsolve/iterative.go
@@ -199,6 +199,8 @@ func Iterative(a MulVecToer, b []float64, m Method, settings *Settings) (*Result
 	ctx.ResidualNorm = floats.Norm(ctx.Residual, 2)
 	if ctx.ResidualNorm >= s.Tolerance {
 		err = iterate(a, b, s, m, &stats)
+	} else {
+		copy(s.Dst, ctx.X)
 	}
 
 	return &Result{

--- a/linsolve/iterative_test.go
+++ b/linsolve/iterative_test.go
@@ -53,8 +53,9 @@ func testIterative(t *testing.T, m Method, testCases []testCase) {
 			x[i] = rnd.NormFloat64()
 		}
 
-		_, err := Iterative(x, tc, b, m, &Settings{
+		_, err := Iterative(tc, b, m, &Settings{
 			InitX:         x,
+			Dst:           x,
 			Tolerance:     convTol,
 			MaxIterations: 40 * n,
 		})

--- a/linsolve/iterative_test.go
+++ b/linsolve/iterative_test.go
@@ -53,7 +53,7 @@ func testIterative(t *testing.T, m Method, testCases []testCase) {
 			x[i] = rnd.NormFloat64()
 		}
 
-		_, err := Iterative(x, tc, b, m, Settings{
+		_, err := Iterative(x, tc, b, m, &Settings{
 			InitX:         x,
 			Tolerance:     convTol,
 			MaxIterations: 40 * n,

--- a/linsolve/linsolve.go
+++ b/linsolve/linsolve.go
@@ -65,6 +65,30 @@ type Context struct {
 	Src, Dst []float64
 }
 
+// NewContext allocates and returns a Context for solving n-dimensional problems.
+func NewContext(n int) *Context {
+	if n <= 0 {
+		panic("linsolve: context size is not positive")
+	}
+	return &Context{
+		X:        make([]float64, n),
+		Residual: make([]float64, n),
+		Src:      make([]float64, n),
+		Dst:      make([]float64, n),
+	}
+}
+
+func reuseContext(ctx *Context, n int) *Context {
+	if ctx == nil {
+		return NewContext(n)
+	}
+	ctx.X = reuse(ctx.X, n)
+	ctx.Residual = reuse(ctx.Residual, n)
+	ctx.Src = reuse(ctx.Src, n)
+	ctx.Dst = reuse(ctx.Dst, n)
+	return ctx
+}
+
 // Operation specifies the type of operation.
 type Operation uint
 

--- a/linsolve/linsolve.go
+++ b/linsolve/linsolve.go
@@ -78,15 +78,11 @@ func NewContext(n int) *Context {
 	}
 }
 
-func reuseContext(ctx *Context, n int) *Context {
-	if ctx == nil {
-		return NewContext(n)
-	}
+func (ctx *Context) Reset(n int) {
 	ctx.X = reuse(ctx.X, n)
 	ctx.Residual = reuse(ctx.Residual, n)
 	ctx.Src = reuse(ctx.Src, n)
 	ctx.Dst = reuse(ctx.Dst, n)
-	return ctx
 }
 
 // Operation specifies the type of operation.


### PR DESCRIPTION
This PR makes changes suggested by @btracey : 
* move `dst` parameter into `Settings`
* add `Context` to `Settings` so that it can be reused to reduce memory allocations.

There are also some other related changes like passing `Settings` to `Iterative` by pointer.

I'm quite happy with the changes and how they simplify the API of `Iterative`.

I've also tried adding detection when a method is not making any progress but in the end decided against it. The check would have to have a tolerance, but even if it was the machine epsilon, the convergence pattern is in general unpredictable and this could lead to false positives. I left the commits there for reference.