### PR TITLE
coveralls: paper over service flakiness

### DIFF
--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -31,4 +31,4 @@ echo "mode: set" > $ACC_OUT
 find . -type d | while read d; do testCover $d || exit; done
 
 # Upload the coverage profile to coveralls.io
-[ -n "$COVERALLS_TOKEN" ] && goveralls -coverprofile=$ACC_OUT -service=travis-ci -repotoken $COVERALLS_TOKEN
+[ -n "$COVERALLS_TOKEN" ] && ( goveralls -coverprofile=$ACC_OUT -service=travis-ci -repotoken $COVERALLS_TOKEN || echo -e '\n\e[31mCoveralls failed.\n' )


### PR DESCRIPTION
Coveralls has been really flakey for the past few days, failing to collect data from builds and causing otherwise successful builds to fail. There appears to be a long history to this, so rather than losing/hiding success information just warn on Coveralls failure.

Please take a look.

Ameliorates lemurheavy/coveralls-public#1264.
